### PR TITLE
Enable Ledger support by default in install script

### DIFF
--- a/crates/sigil-mother/src/ledger.rs
+++ b/crates/sigil-mother/src/ledger.rs
@@ -22,8 +22,6 @@ use sha2::{Digest, Sha256};
 use tracing::{debug, info, warn};
 
 #[cfg(feature = "ledger")]
-use ledger_transport::Exchange;
-#[cfg(feature = "ledger")]
 use ledger_transport_hid::TransportNativeHID;
 
 /// Ethereum app CLA (instruction class)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -116,7 +116,7 @@ build_sigil() {
     cargo build --release --quiet \
         -p sigil-daemon \
         -p sigil-cli \
-        -p sigil-mother \
+        -p sigil-mother --features sigil-mother/ledger \
         -p sigil-frost --all-features \
         -p sigil-mcp \
         2>&1 | grep -v "Compiling\|Downloading" || true


### PR DESCRIPTION
## Summary
- Update install script to build sigil-mother with `--features sigil-mother/ledger` by default
- Fix build error in ledger feature code that referenced non-existent `sigil_core::ColdMasterShard` type
- Remove unused import and fix clippy warnings in ledger code

## Changes
- `scripts/install.sh`: Add `--features sigil-mother/ledger` to cargo build command
- `crates/sigil-mother/src/main.rs`: Use correct `MasterShardData::new()` instead of non-existent type
- `crates/sigil-mother/src/ledger.rs`: Remove unused import

## Test plan
- [x] Verify install script syntax with `./scripts/install.sh --help`
- [x] Build sigil-mother with ledger feature: `cargo build -p sigil-mother --features sigil-mother/ledger`
- [x] Verify `sigil-mother ledger-status` command exists and works
- [x] Run tests: `cargo test -p sigil-mother --features sigil-mother/ledger`
- [x] Run clippy: `cargo clippy -p sigil-mother --features sigil-mother/ledger`

🤖 Generated with [Claude Code](https://claude.com/claude-code)