### PR TITLE
Enable deterministic recovery for Ledger-derived master keys

### DIFF
--- a/crates/sigil-mother/src/main.rs
+++ b/crates/sigil-mother/src/main.rs
@@ -155,6 +155,8 @@ async fn main() -> anyhow::Result<()> {
                         "Ledger Public Key: 0x{}",
                         hex::encode(output.ledger_pubkey)
                     );
+                    println!("\n✓ RECOVERY: Both shards can be recovered from your Ledger's seed phrase.");
+                    println!("  Keep your Ledger's 24-word recovery phrase safe - it backs up these keys.");
                     println!("\n⚠️  IMPORTANT: The agent shard must be securely transferred to the agent device.");
                     println!(
                         "Agent Master Shard: 0x{}",
@@ -162,10 +164,6 @@ async fn main() -> anyhow::Result<()> {
                     );
                     println!(
                         "\n⚠️  Write down or securely store the agent shard, then clear your terminal."
-                    );
-                    println!(
-                        "\nDerivation message (keep for recovery): {}",
-                        output.derivation_message
                     );
 
                     info!("Master shard saved to {:?}", cli.data_dir);


### PR DESCRIPTION
## Summary
Fix Ledger initialization to enable deterministic recovery of master keys from the Ledger's seed phrase.

## Problem
Previously, Ledger-derived master keys were NOT recoverable because:
1. The derivation message included a timestamp (changed daily)
2. The agent shard was randomly generated (not from Ledger)

## Solution
Both shards are now deterministically derived from Ledger signatures:
- **Cold shard**: derived from signing fixed message `"Sigil MPC Cold Master Shard Derivation v1"`
- **Agent shard**: derived from signing fixed message `"Sigil MPC Agent Master Shard Derivation v1"`

## Changes
- `crates/sigil-mother/src/ledger.rs`: Use fixed derivation messages, derive both shards from Ledger signatures
- `crates/sigil-mother/src/main.rs`: Update messaging to reflect recoverability

## Test plan
- [x] Build with ledger feature: `cargo build -p sigil-mother --features sigil-mother/ledger`
- [x] Run tests: `cargo test -p sigil-mother --features sigil-mother/ledger`
- [x] Run clippy: `cargo clippy -p sigil-mother --features sigil-mother/ledger`
- [x] **Tested recovery with actual Ledger Nano X** - Confirmed identical shards after delete/reinit

## Recovery Test Results
| Field | First Init | Second Init | Match |
|-------|------------|-------------|-------|
| cold_master_shard | `9d657e04...` | `9d657e04...` | ✓ |
| master_pubkey | `022de282...` | `022de282...` | ✓ |
| Agent Shard | `84873d5d...` | `84873d5d...` | ✓ |

## Breaking Change
Initialization now requires **TWO confirmations** on the Ledger device (one for each shard derivation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)